### PR TITLE
vpc peering inter region fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ Notes:
    - [Intra VPC Security Group Rule](https://github.com/JudeQuintana/terraform-aws-intra-vpc-security-group-rule)
    - [Super Intra VPC Secuity Group Rules](https://github.com/JudeQuintana/terraform-aws-super-intra-vpc-security-group-rules)
    - [Full Mesh Intra VPC Secuity Group Rules](https://github.com/JudeQuintana/terraform-aws-full-mesh-intra-vpc-security-group-rules)
- - There is no overlapping CIDR detection so it's important that the VPC's network and subnet CIDRs are allocated correctly across regions.
- - Demos can be used with AWS 5.x provider but there will be a warning about a `aws_eip` attribute deprecation. Should still work when enabling NATGW for a given AZ.
+ - There is no overlapping CIDR detection across regions so it's important that the VPC's network and subnet CIDRs are allocated correctly.
+ - Demos can be used with AWS 4.x and 5.x providers but there will be a warning about a `aws_eip` attribute deprecation for Tiered VPC-NG for 5.x. Should still work when enabling NATGW for a given AZ.

--- a/full_mesh_trio_demo/README.md
+++ b/full_mesh_trio_demo/README.md
@@ -10,7 +10,7 @@ The resulting architecture is a full mesh between 3 cross-region hub spoke topol
 
 [VPC Peering Deluxe module](https://github.com/JudeQuintana/terraform-aws-vpc-peering-deluxe):
  - VPC Peering Deluxe module will create appropriate routes for all subnets in each cross region Tiered VPC-NG by default
- - The module should also work for inter region VPCs.
+ - The module also works for inter region VPCs.
  - Specific subnet cidrs can be selected (instead of default behavior) to route across the VPC peering connection via only_route_subnet_cidrs variable list.
  - Additional option to allow remote dns resolution too.
  - Can be used in tandem with Centralized Router, Super Router and Full Mesh Trio for workloads that transfer lots of data to save on cost instead of via TGW (especially inter region).
@@ -19,7 +19,7 @@ Important:
  - If you've ran this demo before then it's possible that you'll need to run `terraform get -update` to get the updated Tiered VPC-NG outputs needed for VPC Pering Deluxe.
 
 cross region Full mesh with cross region VPC peering:
-![full-mesh-trio-with-vpc-peering](https://jq1-io.s3.amazonaws.com/full-mesh-trio/full-mesh-trio-with-vpc-peering.png)
+![full-mesh-trio-with-vpc-peering](https://jq1-io.s3.amazonaws.com/full-mesh-trio/full-mesh-trio-with-two-vpc-peering-examples.png)
 
 ---
 
@@ -32,19 +32,21 @@ Demo:
 This demo will be creating 6 VPCs (2 in each region) and 3 TGWs (1 in each region)
 
 It begins:
- - `terraform init`
+ 1. `terraform init`
 
 Apply Tiered-VPCs (must exist before Centralized Routers, VPC Peering Deluxe and Full Mesh Intra VPC Security Group Rules):
- - `terraform apply -target module.vpcs_use1 -target module.vpcs_use2 -target module.vpcs_usw2`
+ 2. `terraform apply -target module.vpcs_use1 -target module.vpcs_use2 -target module.vpcs_usw2`
 
 Apply Full Mesh Intra VPC Security Group Rules (will auto apply it's dependent modules Intra Security Group Rules for each region) for EC2 access across VPC regions (ie ssh and ping) for VPCs in a TGW Full Mesh configuration.
- - `terraform apply -target module.full_mesh_intra_vpc_security_group_rules`
+ 3. `terraform apply -target module.full_mesh_intra_vpc_security_group_rules`
 
 Apply VPC Peering Deluxe and Centralized Routers (must exist before Full Mesh Trio):
- - `terraform apply -target module.vpc_peering_deluxe_use1_general2_to_use2_cicd1 -target module.centralized_router_use1 -target module.centralized_router_use2 -target module.centralized_router_usw2`
+ 4. `terraform apply -target module.vpc_peering_deluxe_use1_general2_to_use2_cicd1 -target module.vpc_peering_deluxe_usw2_app1_to_usw2_general1 -target module.centralized_router_use1 -target module.centralized_router_use2 -target module.centralized_router_usw2`
 
 Apply Full Mesh Trio:
- - `terraform apply -target module.full_mesh_trio`
+ 5. `terraform apply -target module.full_mesh_trio`
+
+Note: You can combine steps 3 though 5 with `terraform apply`
 
 Full Mesh Trio is now complete!
 

--- a/full_mesh_trio_demo/vpc_peering.tf
+++ b/full_mesh_trio_demo/vpc_peering.tf
@@ -1,4 +1,6 @@
-# VPC Peering Deluxe module will create appropriate routes for all subnets in each cross region Tiered VPC-NG by default unless specific subnet cidrs are selected to route across the VPC peering connection via only_route_subnet_cidrs list.
+#VPC Peering Deluxe module will create appropriate routes for all subnets in each cross region Tiered VPC-NG by default unless specific subnet cidrs are selected to route across the VPC peering connection via only_route_subnet_cidrs list.
+
+# cross region peering, route specific subnets only across peering connection
 module "vpc_peering_deluxe_use1_general2_to_use2_cicd1" {
   source  = "JudeQuintana/vpc-peering-deluxe/aws"
   version = "1.0.0"
@@ -19,6 +21,27 @@ module "vpc_peering_deluxe_use1_general2_to_use2_cicd1" {
       vpc = lookup(module.vpcs_use2, "cicd1")
       # use2 private jenkins1
       only_route_subnet_cidrs = ["172.16.1.0/24"]
+    }
+  }
+}
+
+## inter region vpc peering, route all subnets across peering connection
+module "vpc_peering_deluxe_usw2_app1_to_usw2_general1" {
+  source  = "JudeQuintana/vpc-peering-deluxe/aws"
+  version = "1.0.0"
+
+  providers = {
+    aws.local = aws.usw2
+    aws.peer  = aws.usw2
+  }
+
+  env_prefix = var.env_prefix
+  vpc_peering_deluxe = {
+    local = {
+      vpc = lookup(module.vpcs_usw2, "app1")
+    }
+    peer = {
+      vpc = lookup(module.vpcs_usw2, "general1")
     }
   }
 }

--- a/full_mesh_trio_demo/vpcs_use1.tf
+++ b/full_mesh_trio_demo/vpcs_use1.tf
@@ -32,6 +32,16 @@ locals {
       name         = "general2"
       network_cidr = "192.168.0.0/20"
       azs = {
+        a = {
+          private_subnets = [
+            { name = "data1", cidr = "192.168.0.0/24" },
+            { name = "data2", cidr = "192.168.1.0/24" }
+          ]
+          public_subnets = [
+            { name = "random4", cidr = "192.168.5.0/28", special = true },
+            { name = "haproxy4", cidr = "192.168.6.64/26" }
+          ]
+        }
         c = {
           private_subnets = [
             { name = "experiment1", cidr = "192.168.10.0/24" },
@@ -48,8 +58,9 @@ locals {
 }
 
 module "vpcs_use1" {
-  source  = "JudeQuintana/tiered-vpc-ng/aws"
-  version = "1.0.0"
+  #source  = "JudeQuintana/tiered-vpc-ng/aws"
+  #version = "1.0.0"
+  source = "/Users/jude/projects/terraform-modules/networking/tiered_vpc_ng"
 
   providers = {
     aws = aws.use1

--- a/full_mesh_trio_demo/vpcs_use1.tf
+++ b/full_mesh_trio_demo/vpcs_use1.tf
@@ -58,9 +58,8 @@ locals {
 }
 
 module "vpcs_use1" {
-  #source  = "JudeQuintana/tiered-vpc-ng/aws"
-  #version = "1.0.0"
-  source = "/Users/jude/projects/terraform-modules/networking/tiered_vpc_ng"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use1

--- a/full_mesh_trio_demo/vpcs_use2.tf
+++ b/full_mesh_trio_demo/vpcs_use2.tf
@@ -13,7 +13,15 @@ locals {
           ]
           public_subnets = [
             { name = "random1", cidr = "172.16.6.0/26" },
-            { name = "natgw", cidr = "172.16.5.0/28", special = true }
+            { name = "natgw1", cidr = "172.16.5.0/28", special = true }
+          ]
+        }
+        b = {
+          private_subnets = [
+            { name = "artifacts1", cidr = "172.16.10.0/24" }
+          ]
+          public_subnets = [
+            { name = "attachments1", cidr = "172.16.11.0/28", special = true }
           ]
         }
       }
@@ -22,12 +30,20 @@ locals {
       name         = "infra1"
       network_cidr = "172.16.16.0/20"
       azs = {
+        a = {
+          private_subnets = [
+            { name = "artifacts2", cidr = "172.16.22.0/24" }
+          ]
+          public_subnets = [
+            { name = "random1", cidr = "172.16.23.0/28", special = true }
+          ]
+        }
         c = {
           private_subnets = [
             { name = "jenkins2", cidr = "172.16.16.0/24" }
           ]
           public_subnets = [
-            { name = "random1", cidr = "172.16.19.0/28", special = true }
+            { name = "random2", cidr = "172.16.19.0/28", special = true }
           ]
         }
       }
@@ -36,8 +52,9 @@ locals {
 }
 
 module "vpcs_use2" {
-  source  = "JudeQuintana/tiered-vpc-ng/aws"
-  version = "1.0.0"
+  #source  = "JudeQuintana/tiered-vpc-ng/aws"
+  #version = "1.0.0"
+  source = "/Users/jude/projects/terraform-modules/networking/tiered_vpc_ng"
 
   providers = {
     aws = aws.use2

--- a/full_mesh_trio_demo/vpcs_usw2.tf
+++ b/full_mesh_trio_demo/vpcs_usw2.tf
@@ -32,6 +32,15 @@ locals {
       name         = "general1"
       network_cidr = "192.168.16.0/20"
       azs = {
+        a = {
+          private_subnets = [
+            { name = "cluster4", cidr = "192.168.21.0/24" }
+          ]
+          public_subnets = [
+            { name = "random2", cidr = "192.168.22.0/28", special = true },
+            { name = "haproxy1", cidr = "192.168.23.64/26" }
+          ]
+        }
         c = {
           private_subnets = [
             { name = "experiment1", cidr = "192.168.16.0/24" }


### PR DESCRIPTION
Full Mesh Trio Demo Updates:
- vpc peering deluxe can be used in a cross region and inter region configuration
- made updates to tiered-vpc-ng outputs so that vpc peering deluxe modules can route more than one AZ.
- added more AZs to each VPC for a better demo.
- might need to run `terraform get -update` to get the upgrade.