### PR TITLE
switch sources back to public registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,12 @@
 --=[ #StayUp ]=--
 ```
 ---
-Update 1/22/2024:
- - The Terraform Public Registry is not syncing some of the modules
-   correctly and can't get necessary updates.
- - I've pointed all module sources directly to github repos (same
-   repos that the public registry points to) for all demos so that they
-   continue to be able to work together.
- - The current registry modules will work together but
-   won't work with the new Mega Mesh module until it's sorted out so it
-   will remain unpublished on the registry.
+Update 1/27/2024:
+ - The Terraform Public Registry is mostly* syncing modules correctly again
+   so've pointed all module sources back to the public registry.
+ - The new Mega Mesh module is now published and all registry modules will continue work together.
+ - *The VPC peering deluxe module is the only one not syncing correctly
+    but will work for both stale and new versions. I'm hoping this will be fix soon.
 
 ---
 
@@ -56,6 +53,8 @@ Notes:
    - [Super Intra VPC Security Group Rules](https://github.com/JudeQuintana/terraform-aws-super-intra-vpc-security-group-rules)
    - [Full Mesh Intra VPC Security Group Rules](https://github.com/JudeQuintana/terraform-aws-full-mesh-intra-vpc-security-group-rules)
    - TODO: Mega Mesh Intra VPC Security Group Rules
+  - Available AZs (a,b,c etc) region are different per AWS account (ie. your us-west-2a is not the same AZ as my us-west-2a AZ)
+    so it's possible you'll need to change the AZ letter for a VPC if the provider saying it's not available for the region.
  - There is no overlapping CIDR detection cross region or intra region so it's important that the VPC's network and subnet CIDRs are allocated correctly.
  - Demos can be used with AWS 4.x and 5.x providers but there will be a warning about a `aws_eip` attribute deprecation for Tiered VPC-NG for 5.x.
    - Should still work when enabling NATGW for a given AZ.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Notes:
    - [Super Intra VPC Security Group Rules](https://github.com/JudeQuintana/terraform-aws-super-intra-vpc-security-group-rules)
    - [Full Mesh Intra VPC Security Group Rules](https://github.com/JudeQuintana/terraform-aws-full-mesh-intra-vpc-security-group-rules)
    - TODO: Mega Mesh Intra VPC Security Group Rules
-  - Available AZs (a,b,c etc) region are different per AWS account (ie. your us-west-2a is not the same AZ as my us-west-2a AZ)
+  - Available AZs (a,b,c etc) in a region are different per AWS account (ie. your us-west-2a is not the same AZ as my us-west-2a AZ)
     so it's possible you'll need to change the AZ letter for a VPC if the provider saying it's not available for the region.
  - There is no overlapping CIDR detection cross region or intra region so it's important that the VPC's network and subnet CIDRs are allocated correctly.
  - Demos can be used with AWS 4.x and 5.x providers but there will be a warning about a `aws_eip` attribute deprecation for Tiered VPC-NG for 5.x.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Update 1/27/2024:
    so've pointed all module sources back to the public registry.
  - The new Mega Mesh module is now published and all registry modules will continue work together.
  - *The VPC peering deluxe module is the only one not syncing correctly
-    but will work for both stale and new versions. I'm hoping this will be fix soon.
+    but will work for both stale and new versions. I'm hoping this will be fixed soon otherwise you can use `source = "git@github.com:JudeQuintana/terraform-aws-vpc-peering-deluxe.git?ref=v1.0.0"`.
 
 ---
 

--- a/full_mesh_trio_demo/README.md
+++ b/full_mesh_trio_demo/README.md
@@ -9,14 +9,14 @@ The resulting architecture is a full mesh between 3 cross-region hub spoke topol
 ### Bonus Update!
 
 [VPC Peering Deluxe module](https://github.com/JudeQuintana/terraform-aws-vpc-peering-deluxe):
- - VPC Peering Deluxe module will create appropriate routes for all subnets in each cross region Tiered VPC-NG by default
+ - VPC Peering Deluxe module will create appropriate routes for all subnets in each cross region Tiered VPC-NG by default.
  - The module also works for inter region VPCs.
  - Specific subnet cidrs can be selected (instead of default behavior) to route across the VPC peering connection via only_route_subnet_cidrs variable list.
  - Additional option to allow remote dns resolution too.
- - Can be used in tandem with Centralized Router, Super Router and Full Mesh Trio for workloads that transfer lots of data to save on cost instead of via TGW (especially inter region).
+ - Can be used in tandem with Centralized Router, Super Router, Full Mesh Trio and Mega Mesh for workloads that transfer lots of data to save on cost instead of via TGW (especially inter region).
 
 Important:
- - If you've ran this demo before then it's possible that you'll need to run `terraform get -update` to get the updated Tiered VPC-NG outputs needed for VPC Pering Deluxe.
+ - If you've ran this demo before then it's possible that you'll need to run `terraform get -update` to get the updated Tiered VPC-NG outputs needed for VPC Peering Deluxe.
 
 cross region Full mesh with cross region and inter region VPC peering:
 ![full-mesh-trio-with-vpc-peering](https://jq1-io.s3.amazonaws.com/full-mesh-trio/full-mesh-trio-with-two-vpc-peering-examples.png)
@@ -24,7 +24,7 @@ cross region Full mesh with cross region and inter region VPC peering:
 ---
 
 Related articles:
-- Blog Post in coming soon...
+- Blog Post coming soon...
 
 Demo:
 - Pre-requisite: AWS account, may need to increase your VPC and or TGW quota for

--- a/full_mesh_trio_demo/centralized_router_use1.tf
+++ b/full_mesh_trio_demo/centralized_router_use1.tf
@@ -2,7 +2,8 @@
 # associate and propagate to a single route table
 # generate and add routes in each VPC to all other networks.
 module "centralized_router_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use1

--- a/full_mesh_trio_demo/centralized_router_use2.tf
+++ b/full_mesh_trio_demo/centralized_router_use2.tf
@@ -1,5 +1,6 @@
 module "centralized_router_use2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use2

--- a/full_mesh_trio_demo/centralized_router_usw2.tf
+++ b/full_mesh_trio_demo/centralized_router_usw2.tf
@@ -1,5 +1,6 @@
 module "centralized_router_usw2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw2

--- a/full_mesh_trio_demo/full_mesh_trio.tf
+++ b/full_mesh_trio_demo/full_mesh_trio.tf
@@ -1,5 +1,6 @@
 module "full_mesh_trio" {
-  source = "git@github.com:JudeQuintana/terraform-aws-full-mesh-trio.git?ref=v1.0.0"
+  source  = "JudeQuintana/full-mesh-trio/aws"
+  version = "1.0.0"
 
   providers = {
     aws.one   = aws.use1

--- a/full_mesh_trio_demo/security_group_rules.tf
+++ b/full_mesh_trio_demo/security_group_rules.tf
@@ -17,7 +17,8 @@ locals {
 }
 
 module "intra_vpc_security_group_rules_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-intra-vpc-security-group-rule.git?ref=v1.0.0"
+  source  = "JudeQuintana/intra-vpc-security-group-rule/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use1
@@ -34,7 +35,8 @@ module "intra_vpc_security_group_rules_use1" {
 }
 
 module "intra_vpc_security_group_rules_use2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-intra-vpc-security-group-rule.git?ref=v1.0.0"
+  source  = "JudeQuintana/intra-vpc-security-group-rule/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use2
@@ -51,7 +53,8 @@ module "intra_vpc_security_group_rules_use2" {
 }
 
 module "intra_vpc_security_group_rules_usw2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-intra-vpc-security-group-rule.git?ref=v1.0.0"
+  source  = "JudeQuintana/intra-vpc-security-group-rule/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw2
@@ -69,7 +72,8 @@ module "intra_vpc_security_group_rules_usw2" {
 
 # allow all ssh and ping communication between all VPCs across regions in each intra-vpc security group
 module "full_mesh_intra_vpc_security_group_rules" {
-  source = "git@github.com:JudeQuintana/terraform-aws-full-mesh-intra-vpc-security-group-rules.git?ref=v1.0.0"
+  source  = "JudeQuintana/full-mesh-intra-vpc-security-group-rules/aws"
+  version = "1.0.0"
 
   providers = {
     aws.one   = aws.use1

--- a/full_mesh_trio_demo/vpc_peering.tf
+++ b/full_mesh_trio_demo/vpc_peering.tf
@@ -2,7 +2,8 @@
 
 # cross region peering, route specific subnets only across peering connection
 module "vpc_peering_deluxe_use1_general2_to_use2_cicd1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-vpc-peering-deluxe.git?ref=v1.0.0"
+  source  = "JudeQuintana/vpc-peering-deluxe/aws"
+  version = "1.0.0"
 
   providers = {
     aws.local = aws.use1
@@ -26,7 +27,8 @@ module "vpc_peering_deluxe_use1_general2_to_use2_cicd1" {
 
 ## inter region vpc peering, route all subnets across peering connection
 module "vpc_peering_deluxe_usw2_app1_to_usw2_general1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-vpc-peering-deluxe.git?ref=v1.0.0"
+  source  = "JudeQuintana/vpc-peering-deluxe/aws"
+  version = "1.0.0"
 
   providers = {
     aws.local = aws.usw2

--- a/full_mesh_trio_demo/vpcs_use1.tf
+++ b/full_mesh_trio_demo/vpcs_use1.tf
@@ -56,7 +56,8 @@ locals {
 }
 
 module "vpcs_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use1

--- a/full_mesh_trio_demo/vpcs_use2.tf
+++ b/full_mesh_trio_demo/vpcs_use2.tf
@@ -52,7 +52,8 @@ locals {
 }
 
 module "vpcs_use2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use2

--- a/full_mesh_trio_demo/vpcs_usw2.tf
+++ b/full_mesh_trio_demo/vpcs_usw2.tf
@@ -54,7 +54,8 @@ locals {
 }
 
 module "vpcs_usw2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw2

--- a/mega_mesh_demo/README.md
+++ b/mega_mesh_demo/README.md
@@ -31,7 +31,7 @@ Notes:
   - You can combine steps 3 and 4 with `terraform apply`.
   - Add blackhole cidrs on any centralized router via the
     `var.centralized_router.blackhole_cidrs` list to create blackhole routes or aggregate routes.
-  - Available AZs (a,b,c etc) region are different per AWS account (ie. your us-west-2a is not the same AZ as my us-west-2a AZ)
+  - Available AZs (a,b,c etc) in a region are different per AWS account (ie. your us-west-2a is not the same AZ as my us-west-2a AZ)
     so it's possible you'll need to change the AZ letter for a VPC if the provider saying it's not available for the region.
 
 Routing and peering validation with AWS Route Analyzer:

--- a/mega_mesh_demo/README.md
+++ b/mega_mesh_demo/README.md
@@ -6,15 +6,10 @@ Mega Mesh == (Full Mesh Trio)² + 1
 ![mega-mesh](https://jq1-io.s3.amazonaws.com/mega-mesh/ten-full-mesh-tgw.png)
 
 ---
-Update 1/22/2024:
- - The Terraform Public Registry is not syncing some of the modules
-   correctly and can't get necessary updates.
- - I've pointed all module sources directly to github repos (same
-   repos that the public registry points to) for all demos so that they
-   continue to be able to work together.
- - The current registry modules will continue to work together but
-   won't work with the new Mega Mesh module until it's sorted out so it
-   will remain unpublished on the registry.
+Update 1/27/2024:
+ - The Terraform Public Registry is mostly* syncing modules correctly again
+   so've pointed all module sources back to the public registry.
+ - The new Mega Mesh module is now published and all registry modules will continue work together.
 
 ---
 
@@ -35,10 +30,9 @@ Mesh Complete!
 Notes:
   - You can combine steps 3 and 4 with `terraform apply`.
   - Add blackhole cidrs on any centralized router via the
-    `var.blackhole_cidrs` list to create blackhole
-    routes or aggregate routes.
-  - AZs (a,b,c etc) that are not opt-in for a region are different per AWS account
-    so it's possible you'll need to change the AZ letter for a VPC if it's saying it's not available for the region.
+    `var.centralized_router.blackhole_cidrs` list to create blackhole routes or aggregate routes.
+  - Available AZs (a,b,c etc) region are different per AWS account (ie. your us-west-2a is not the same AZ as my us-west-2a AZ)
+    so it's possible you'll need to change the AZ letter for a VPC if the provider saying it's not available for the region.
 
 Routing and peering validation with AWS Route Analyzer:
 - Go to [AWS Network Manager](https://us-west-2.console.aws.amazon.com/networkmanager/home?region=us-east-1#/networks) (free to use)

--- a/mega_mesh_demo/centralized_router_apne1.tf
+++ b/mega_mesh_demo/centralized_router_apne1.tf
@@ -1,5 +1,6 @@
 module "centralized_router_apne1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.apne1

--- a/mega_mesh_demo/centralized_router_apse1.tf
+++ b/mega_mesh_demo/centralized_router_apse1.tf
@@ -1,5 +1,6 @@
 module "centralized_router_apse1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.apse1

--- a/mega_mesh_demo/centralized_router_cac1.tf
+++ b/mega_mesh_demo/centralized_router_cac1.tf
@@ -1,5 +1,6 @@
 module "centralized_router_cac1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.cac1

--- a/mega_mesh_demo/centralized_router_euc1.tf
+++ b/mega_mesh_demo/centralized_router_euc1.tf
@@ -1,5 +1,6 @@
 module "centralized_router_euc1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.euc1

--- a/mega_mesh_demo/centralized_router_euw1.tf
+++ b/mega_mesh_demo/centralized_router_euw1.tf
@@ -1,5 +1,6 @@
 module "centralized_router_euw1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.euw1

--- a/mega_mesh_demo/centralized_router_sae1.tf
+++ b/mega_mesh_demo/centralized_router_sae1.tf
@@ -1,5 +1,6 @@
 module "centralized_router_sae1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.sae1

--- a/mega_mesh_demo/centralized_router_use1.tf
+++ b/mega_mesh_demo/centralized_router_use1.tf
@@ -1,5 +1,6 @@
 module "centralized_router_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use1

--- a/mega_mesh_demo/centralized_router_use2.tf
+++ b/mega_mesh_demo/centralized_router_use2.tf
@@ -1,5 +1,6 @@
 module "centralized_router_use2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use2

--- a/mega_mesh_demo/centralized_router_usw1.tf
+++ b/mega_mesh_demo/centralized_router_usw1.tf
@@ -1,5 +1,6 @@
 module "centralized_router_usw1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw1

--- a/mega_mesh_demo/centralized_router_usw2.tf
+++ b/mega_mesh_demo/centralized_router_usw2.tf
@@ -1,5 +1,6 @@
 module "centralized_router_usw2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw2

--- a/mega_mesh_demo/mega_mesh.tf
+++ b/mega_mesh_demo/mega_mesh.tf
@@ -1,5 +1,6 @@
 module "mega_mesh" {
-  source = "git@github.com:JudeQuintana/terraform-aws-mega-mesh.git?ref=v1.0.0"
+  source  = "JudeQuintana/mega-mesh/aws"
+  version = "1.0.0"
 
   providers = {
     aws.one   = aws.use1

--- a/mega_mesh_demo/vpcs_apne1.tf
+++ b/mega_mesh_demo/vpcs_apne1.tf
@@ -51,7 +51,9 @@ locals {
 }
 
 module "vpcs_apne1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
+
 
   providers = {
     aws = aws.apne1

--- a/mega_mesh_demo/vpcs_apse1.tf
+++ b/mega_mesh_demo/vpcs_apse1.tf
@@ -50,7 +50,8 @@ locals {
 }
 
 module "vpcs_apse1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.apse1

--- a/mega_mesh_demo/vpcs_cac1.tf
+++ b/mega_mesh_demo/vpcs_cac1.tf
@@ -55,7 +55,8 @@ locals {
 }
 
 module "vpcs_cac1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.cac1

--- a/mega_mesh_demo/vpcs_euc1.tf
+++ b/mega_mesh_demo/vpcs_euc1.tf
@@ -54,7 +54,8 @@ locals {
 }
 
 module "vpcs_euc1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.euc1

--- a/mega_mesh_demo/vpcs_euw1.tf
+++ b/mega_mesh_demo/vpcs_euw1.tf
@@ -50,7 +50,8 @@ locals {
 }
 
 module "vpcs_euw1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.euw1

--- a/mega_mesh_demo/vpcs_sae1.tf
+++ b/mega_mesh_demo/vpcs_sae1.tf
@@ -50,7 +50,8 @@ locals {
 }
 
 module "vpcs_sae1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.sae1

--- a/mega_mesh_demo/vpcs_use1.tf
+++ b/mega_mesh_demo/vpcs_use1.tf
@@ -56,7 +56,8 @@ locals {
 }
 
 module "vpcs_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use1

--- a/mega_mesh_demo/vpcs_use2.tf
+++ b/mega_mesh_demo/vpcs_use2.tf
@@ -50,7 +50,8 @@ locals {
 }
 
 module "vpcs_use2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use2

--- a/mega_mesh_demo/vpcs_usw1.tf
+++ b/mega_mesh_demo/vpcs_usw1.tf
@@ -50,7 +50,8 @@ locals {
 }
 
 module "vpcs_usw1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw1

--- a/mega_mesh_demo/vpcs_usw2.tf
+++ b/mega_mesh_demo/vpcs_usw2.tf
@@ -50,7 +50,8 @@ locals {
 }
 
 module "vpcs_usw2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw2

--- a/networking_trifecta_demo/centralized_router.tf
+++ b/networking_trifecta_demo/centralized_router.tf
@@ -2,7 +2,8 @@
 # associate and propagate to a single route table
 # generate and add routes in each VPC to all other networks.
 module "centralized_router" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   env_prefix       = var.env_prefix
   region_az_labels = var.region_az_labels

--- a/networking_trifecta_demo/security_group_rules.tf
+++ b/networking_trifecta_demo/security_group_rules.tf
@@ -18,7 +18,8 @@ locals {
 }
 
 module "intra_vpc_security_group_rules" {
-  source = "git@github.com:JudeQuintana/terraform-aws-intra-vpc-security-group-rule.git?ref=v1.0.0"
+  source  = "JudeQuintana/intra-vpc-security-group-rule/aws"
+  version = "1.0.0"
 
   for_each = { for r in local.intra_vpc_security_group_rules : r.label => r }
 

--- a/networking_trifecta_demo/vpcs.tf
+++ b/networking_trifecta_demo/vpcs.tf
@@ -58,7 +58,8 @@ locals {
 }
 
 module "vpcs" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   for_each = { for t in local.tiered_vpcs : t.name => t }
 

--- a/super_router_demo/centralized_routers_use1.tf
+++ b/super_router_demo/centralized_routers_use1.tf
@@ -19,7 +19,8 @@ locals {
 # associate and propagate to a single route table
 # generate and add routes in each VPC to all other networks.
 module "centralized_routers_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use1

--- a/super_router_demo/centralized_routers_usw2.tf
+++ b/super_router_demo/centralized_routers_usw2.tf
@@ -16,7 +16,8 @@ locals {
 }
 
 module "centralized_routers_usw2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-centralized-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/centralized-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw2

--- a/super_router_demo/security_group_rules.tf
+++ b/super_router_demo/security_group_rules.tf
@@ -19,7 +19,8 @@ locals {
 }
 
 module "intra_vpc_security_group_rules_usw2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-intra-vpc-security-group-rule.git?ref=v1.0.0"
+  source  = "JudeQuintana/intra-vpc-security-group-rule/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw2
@@ -36,7 +37,8 @@ module "intra_vpc_security_group_rules_usw2" {
 }
 
 module "intra_vpc_security_group_rules_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-intra-vpc-security-group-rule.git?ref=v1.0.0"
+  source  = "JudeQuintana/intra-vpc-security-group-rule/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use1
@@ -54,7 +56,8 @@ module "intra_vpc_security_group_rules_use1" {
 
 # allowing ssh and ping communication across regions
 module "super_intra_vpc_security_group_rules_usw2_to_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-super-intra-vpc-security-group-rules.git?ref=v1.0.0"
+  source  = "JudeQuintana/super-intra-vpc-security-group-rules/aws"
+  version = "1.0.0"
 
   providers = {
     aws.local = aws.usw2

--- a/super_router_demo/super_router_usw2_to_use1.tf
+++ b/super_router_demo/super_router_usw2_to_use1.tf
@@ -1,6 +1,7 @@
 # Super Router is composed of two TGWs, one in each region.
 module "super_router_usw2_to_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-super-router.git?ref=v1.0.0"
+  source  = "JudeQuintana/super-router/aws"
+  version = "1.0.0"
 
   providers = {
     aws.local = aws.usw2 # local super router tgw will be built in the aws.local provider region

--- a/super_router_demo/vpcs_use1.tf
+++ b/super_router_demo/vpcs_use1.tf
@@ -48,7 +48,8 @@ locals {
 }
 
 module "vpcs_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use1
@@ -98,7 +99,8 @@ locals {
 }
 
 module "vpcs_another_use1" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.use1

--- a/super_router_demo/vpcs_usw2.tf
+++ b/super_router_demo/vpcs_usw2.tf
@@ -47,7 +47,8 @@ locals {
 }
 
 module "vpcs_usw2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw2
@@ -96,7 +97,8 @@ locals {
 }
 
 module "vpcs_another_usw2" {
-  source = "git@github.com:JudeQuintana/terraform-aws-tiered-vpc-ng.git?ref=v1.0.0"
+  source  = "JudeQuintana/tiered-vpc-ng/aws"
+  version = "1.0.0"
 
   providers = {
     aws = aws.usw2


### PR DESCRIPTION

Update 1/27/2024:
 - The Terraform Public Registry is mostly* syncing modules correctly again
   so've pointed all module sources back to the public registry.
 - The new Mega Mesh module is now published and all registry modules will continue work together.
 - *The VPC peering deluxe module is the only one not syncing correctly
    but will work for both stale and new versions. I'm hoping this will be fixed soon otherwise you can use `source = "git@github.com:JudeQuintana/terraform-aws-vpc-peering-deluxe.git?ref=v1.0.0"`.