### PR TITLE
fix centralized router blackhole overrides

### DIFF
--- a/dual_stack_full_mesh_trio_demo/centralized_router_use1.tf
+++ b/dual_stack_full_mesh_trio_demo/centralized_router_use1.tf
@@ -1,6 +1,6 @@
 module "centralized_router_use1" {
   source  = "JudeQuintana/centralized-router/aws"
-  version = "1.0.3"
+  version = "1.0.4"
 
   providers = {
     aws = aws.use1

--- a/dual_stack_full_mesh_trio_demo/centralized_router_use2.tf
+++ b/dual_stack_full_mesh_trio_demo/centralized_router_use2.tf
@@ -1,6 +1,6 @@
 module "centralized_router_use2" {
   source  = "JudeQuintana/centralized-router/aws"
-  version = "1.0.3"
+  version = "1.0.4"
 
   providers = {
     aws = aws.use2

--- a/dual_stack_full_mesh_trio_demo/centralized_router_usw2.tf
+++ b/dual_stack_full_mesh_trio_demo/centralized_router_usw2.tf
@@ -1,6 +1,6 @@
 module "centralized_router_usw2" {
   source  = "JudeQuintana/centralized-router/aws"
-  version = "1.0.3"
+  version = "1.0.4"
 
   providers = {
     aws = aws.usw2

--- a/dual_stack_networking_trifecta_demo/README.md
+++ b/dual_stack_networking_trifecta_demo/README.md
@@ -238,7 +238,10 @@ for private IPv6 subnets per AZ to route to the internet.
   - Can be used as a vpc attachemnt when passed to centralized router.
   - EIPs dont use a public pool and will continue to be AWS owned public IPv4 cidrs
 
-Centralized Router `v1.0.3`:
+Centralized Router `v1.0.4`:
+- ability to switch between a blackhole route and a static route that have the same cidr/ipv6\_cidr for vpc attachments.
+
+`v1.0.3`:
 - support for IPv6 secondary cidrs
 - TGW routes for vpc attachments are now static by default instead of
   route propagation.

--- a/dual_stack_networking_trifecta_demo/centralized_router.tf
+++ b/dual_stack_networking_trifecta_demo/centralized_router.tf
@@ -3,7 +3,7 @@
 # hub and spoke
 module "centralized_router" {
   source  = "JudeQuintana/centralized-router/aws"
-  version = "1.0.3"
+  version = "1.0.4"
 
   env_prefix       = var.env_prefix
   region_az_labels = var.region_az_labels


### PR DESCRIPTION
- ability to switch between a blackhole route and a static route that have the same cidr/ipv6\_cidr for vpc attachments.
