### PR TITLE
upgrade vpc modules for individual subnet tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,21 @@
 ```
 ## NEW Centralized Egress Dual Stack Full Mesh Trio!
 [Centralized Egress Dual Stack Full Mesh Trio Demo](https://github.com/JudeQuintana/terraform-main/tree/main/centralized_egress_dual_stack_full_mesh_trio_demo)
- - Compose a Centralized IPv4 Egress and Decentralized IPv6 Egress within a Dual Stack Full Mesh Topology across 3 regions using [Tiered VPC-NG](https://github.com/JudeQuintana/terraform-aws-tiered-vpc-ng/tree/v1.0.6) (at `v1.0.6`), [Centralized Router](https://github.com/JudeQuintana/terraform-aws-centralized-router/tree/v1.0.6) (at `v1.0.6`)  and [Full Mesh Trio](https://github.com/JudeQuintana/terraform-aws-full-mesh-trio/tree/v1.0.1) (at `v1.0.1`) modules.
+ - Compose a Centralized IPv4 Egress and Decentralized IPv6 Egress within a Dual Stack Full Mesh Topology across 3 regions using [Tiered VPC-NG](https://github.com/JudeQuintana/terraform-aws-tiered-vpc-ng/tree/v1.0.7) (at `v1.0.7`), [Centralized Router](https://github.com/JudeQuintana/terraform-aws-centralized-router/tree/v1.0.6) (at `v1.0.6`)  and [Full Mesh Trio](https://github.com/JudeQuintana/terraform-aws-full-mesh-trio/tree/v1.0.1) (at `v1.0.1`) modules.
  - Includes an VPC peering examples within a full mesh configuration used high traffic workloads to save on cost using the [VPC Peering Deluxe](https://github.com/JudeQuintana/terraform-aws-vpc-peering-deluxe/tree/v1.0.1) module (at `v1.0.1`).
  - Requires IPAM Pools for IPv4 and IPv6 cidrs.
  - Validate mesh connectivity with Route Anlyzer.
 
 ## Dual Stack Full Mesh Trio!
 [Dual Stack Full Mesh Trio Demo](https://github.com/JudeQuintana/terraform-main/tree/main/dual_stack_full_mesh_trio_demo)
- - Compose a dual stack Full Mesh Transit Gateway across 3 regions using [Tiered VPC-NG](https://github.com/JudeQuintana/terraform-aws-tiered-vpc-ng/tree/v1.0.6) (at `v1.0.6`), [Centralized Router](https://github.com/JudeQuintana/terraform-aws-centralized-router/tree/v1.0.6) (at `v1.0.6`)  and [Full Mesh Trio](https://github.com/JudeQuintana/terraform-aws-full-mesh-trio/tree/v1.0.1) (at `v1.0.1`) modules.
+ - Compose a dual stack Full Mesh Transit Gateway across 3 regions using [Tiered VPC-NG](https://github.com/JudeQuintana/terraform-aws-tiered-vpc-ng/tree/v1.0.7) (at `v1.0.7`), [Centralized Router](https://github.com/JudeQuintana/terraform-aws-centralized-router/tree/v1.0.6) (at `v1.0.6`)  and [Full Mesh Trio](https://github.com/JudeQuintana/terraform-aws-full-mesh-trio/tree/v1.0.1) (at `v1.0.1`) modules.
  - Includes an VPC peering examples within a full mesh configuration used high traffic workloads to save on cost using the [VPC Peering Deluxe](https://github.com/JudeQuintana/terraform-aws-vpc-peering-deluxe/tree/v1.0.1) module (at `v1.0.1`).
  - Requires IPAM Pools for IPv4 and IPv6 cidrs.
  - Validate connectivity with Route Anlyzer.
 
 ## Dual Stack TNT Architecture!
 [Dual Stack Terraform Networking Trifecta Demo](https://github.com/JudeQuintana/terraform-main/tree/main/dual_stack_networking_trifecta_demo)
- - Compose a dual stack hub and spoke Transit Gateway using [Tiered VPC-NG](https://github.com/JudeQuintana/terraform-aws-tiered-vpc-ng/tree/v1.0.6) (at `v1.0.6`) and [Centralized Router](https://github.com/JudeQuintana/terraform-aws-centralized-router/tree/v1.0.6) (at `v1.0.6`) modules.
+ - Compose a dual stack hub and spoke Transit Gateway using [Tiered VPC-NG](https://github.com/JudeQuintana/terraform-aws-tiered-vpc-ng/tree/v1.0.7) (at `v1.0.7`) and [Centralized Router](https://github.com/JudeQuintana/terraform-aws-centralized-router/tree/v1.0.6) (at `v1.0.6`) modules.
  - Requires IPAM Pools for IPv4 and IPv6 cidrs.
  - Validate connectivity with EC2 instances.
 

--- a/centralized_egress_dual_stack_full_mesh_trio_demo/README.md
+++ b/centralized_egress_dual_stack_full_mesh_trio_demo/README.md
@@ -7,7 +7,7 @@
   - Start with IPv4 only and add IPv6 at a later time or start with both.
   - Should also work with OpenTofu.
 - Demo does not work as-is because these Amazon owned IPv6 CIDRs have been allocated to my AWS account.
-  - You'll need to configure your own IPv4 and IPv6 cidr pools/subpools.
+  - You'll need to configure your own IPv4 and IPv6 cidr pools/subpools and there is IPAM instructions below.
 - AWS general reference: [Centralized Egress](https://docs.aws.amazon.com/whitepapers/latest/building-scalable-secure-multi-vpc-network-infrastructure/using-nat-gateway-for-centralized-egress.html)
 
 ### Centralized IPv4 Egress

--- a/centralized_egress_dual_stack_full_mesh_trio_demo/vpcs_use1.tf
+++ b/centralized_egress_dual_stack_full_mesh_trio_demo/vpcs_use1.tf
@@ -116,7 +116,7 @@ locals {
 
 module "vpcs_use1" {
   source  = "JudeQuintana/tiered-vpc-ng/aws"
-  version = "1.0.6"
+  version = "1.0.7"
 
   providers = {
     aws = aws.use1

--- a/centralized_egress_dual_stack_full_mesh_trio_demo/vpcs_use2.tf
+++ b/centralized_egress_dual_stack_full_mesh_trio_demo/vpcs_use2.tf
@@ -114,7 +114,7 @@ locals {
 
 module "vpcs_use2" {
   source  = "JudeQuintana/tiered-vpc-ng/aws"
-  version = "1.0.6"
+  version = "1.0.7"
 
   providers = {
     aws = aws.use2

--- a/centralized_egress_dual_stack_full_mesh_trio_demo/vpcs_usw2.tf
+++ b/centralized_egress_dual_stack_full_mesh_trio_demo/vpcs_usw2.tf
@@ -121,7 +121,7 @@ locals {
 
 module "vpcs_usw2" {
   source  = "JudeQuintana/tiered-vpc-ng/aws"
-  version = "1.0.6"
+  version = "1.0.7"
 
   providers = {
     aws = aws.usw2

--- a/dual_stack_full_mesh_trio_demo/README.md
+++ b/dual_stack_full_mesh_trio_demo/README.md
@@ -4,6 +4,7 @@
 - Both IPv4 and IPv6 secondary cidrs are supported.
 - Start with IPv4 only and add IPv6 at a later time or start with both.
 - Demo does not work as-is because these Amazon owned IPv6 CIDRs have been allocated to my AWS account.
+- You'll need to configure your own IPv4 and IPv6 cidr pools/subpools and there is IPAM instructions below.
 
 ### VPC CIDRs
 - `us-east-2`

--- a/dual_stack_full_mesh_trio_demo/vpcs_use1.tf
+++ b/dual_stack_full_mesh_trio_demo/vpcs_use1.tf
@@ -106,7 +106,7 @@ locals {
 
 module "vpcs_use1" {
   source  = "JudeQuintana/tiered-vpc-ng/aws"
-  version = "1.0.6"
+  version = "1.0.7"
 
   providers = {
     aws = aws.use1

--- a/dual_stack_full_mesh_trio_demo/vpcs_use2.tf
+++ b/dual_stack_full_mesh_trio_demo/vpcs_use2.tf
@@ -99,7 +99,7 @@ locals {
 
 module "vpcs_use2" {
   source  = "JudeQuintana/tiered-vpc-ng/aws"
-  version = "1.0.6"
+  version = "1.0.7"
 
   providers = {
     aws = aws.use2

--- a/dual_stack_full_mesh_trio_demo/vpcs_usw2.tf
+++ b/dual_stack_full_mesh_trio_demo/vpcs_usw2.tf
@@ -108,7 +108,7 @@ locals {
 
 module "vpcs_usw2" {
   source  = "JudeQuintana/tiered-vpc-ng/aws"
-  version = "1.0.6"
+  version = "1.0.7"
 
   providers = {
     aws = aws.usw2

--- a/dual_stack_networking_trifecta_demo/README.md
+++ b/dual_stack_networking_trifecta_demo/README.md
@@ -1,7 +1,7 @@
 # Dual Stack Networking Trifecta Demo
 - The dual stack version of the (IPv4 only) [Networking Trifecta demo](https://github.com/JudeQuintana/terraform-main/tree/main/networking_trifecta_demo).
 - Demo does not work as-is because these Amazon owned IPv6 CIDRs have been allocated to my AWS account.
-- You'll need to configure your own IPv4 and IPv6 cidr pools/subpools.
+- You'll need to configure your own IPv4 and IPv6 cidr pools/subpools and there is IPAM instructions below.
 - Both IPv4 and IPv6 secondary cidrs are supported.
 - Start with IPv4 only and add IPv6 at a later time or start with both.
 
@@ -236,20 +236,15 @@ Example:
 - Full teardown (destroy) works for AWS provider 5.61.0+ but the VPC destroy in the last step will take about 10-30 min to finish deleting cleanly after waiting for AWS to release IPAM pool CIDRs without error. Now you can immediately rebuild with the same cidrs after the destroy without waiting for IPAM like before (see below). Not sure exactly what the fix was.
 
 ## Caveats
-- Full teardown (destroy) mostly works for AWS provider 5.51.1 and earlier. TF AWS Provider has a bug when a VPC is using an IPv6 allocation from IPAM Advanced Tier. When the VPC is being deleted via Terraform it will time out 15+ min to get a failed apply with `Error: waiting for EC2 VPC IPAM Pool Allocation delete: found resource`. However when actual behavior is that the VPC is deleted but ends up being a failed TF apply with ipam errors. AWS wont release the ipv6 cidr allocations right away (30+ min w/ advanced tier, 24hrs+ with free tier) because it thinks the vpc still exists. Not allowed to manually delete the cidr allocation via console or api so can not release or reuse the allocation until AWS decides to auto release them.
-  - You can Ctrl-C to kill the apply when it tries to delete the vpcs (last step in destroy) or wait until the apply timeout (it will fail). Then if you apply the vpcs again `terraform apply -target module.vpcs` then TF will clean up missing VPCs from state. But you'll have to
-wait until AWS releases deleted cidrs from IPAM if you want to create them again.
-  - Found [this]( https://github.com/hashicorp/terraform-provider-aws/issues/31211) bug report.
-
-  - It does appear aws not releasing the allocation quickly is normal behavior. I can delete the vpc with no failure in the console UI and the allocation is not deleted. So it is a TF AWS provider bug. the possible [workaround](https://github.com/hashicorp/terraform-provider-aws/pull/34628) has yet to be merged. no graceful vpc destroy when using ipam is painful
-
 - The modules build resources that will cost some money but should be minimal for the demo.
-
 - There is no overlapping CIDR detection or validation.
 
 ## Version info
 
-Tiered VPC-NG `v1.0.6`:
+Tiered VPC-NG `v1.0.7`:
+- tag individual private, public or isolated subnets. useful for kubernetes clusters. Not demonstrated in this demo but it is available.
+
+`v1.0.6`:
 - minor: public_az_to_subnet_cidrs and isolated_az_to_subnet_cidrs logic not needed but is required for private_az_to_subnet_cidrs because it is used for route table resource creation.
 
 `v1.0.5`:

--- a/dual_stack_networking_trifecta_demo/vpcs.tf
+++ b/dual_stack_networking_trifecta_demo/vpcs.tf
@@ -130,7 +130,7 @@ locals {
 
 module "vpcs" {
   source  = "JudeQuintana/tiered-vpc-ng/aws"
-  version = "1.0.6"
+  version = "1.0.7"
 
   for_each = { for t in local.tiered_vpcs : t.name => t }
 


### PR DESCRIPTION
tiered vpc-ng module to `v1.0.7`:
-  ability to tag individual private, public or isolated subnets. useful for kubernetes clusters. 
